### PR TITLE
feat: refactor type of client

### DIFF
--- a/.github/workflows/branch-protection.yaml
+++ b/.github/workflows/branch-protection.yaml
@@ -20,3 +20,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
       - run: cargo test
+  check-success:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+    steps:
+      - run: echo true

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,6 @@
+{
+  "format_on_save": "on",
+  "inlay_hints": {
+    "enabled": true
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,8 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
+version = "0.12.1"
+source = "git+https://github.com/deadpool-rs/deadpool?tag=deadpool-postgres-v0.14.1#b438af3524eca9465f15b102ba34c1756d1ffc08"
 dependencies = [
  "deadpool-runtime",
  "num_cpus",
@@ -169,22 +168,20 @@ dependencies = [
 [[package]]
 name = "deadpool-postgres"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+source = "git+https://github.com/deadpool-rs/deadpool?tag=deadpool-postgres-v0.14.1#b438af3524eca9465f15b102ba34c1756d1ffc08"
 dependencies = [
  "async-trait",
  "deadpool",
  "getrandom 0.2.16",
  "tokio",
- "tokio-postgres",
+ "tokio-postgres 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
 [[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+source = "git+https://github.com/deadpool-rs/deadpool?tag=deadpool-postgres-v0.14.1#b438af3524eca9465f15b102ba34c1756d1ffc08"
 dependencies = [
  "tokio",
 ]
@@ -339,6 +336,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -520,15 +523,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.8"
+source = "git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13#ad68abfd48b39a433bb4127bf1ae140b9be64d9e"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
 name = "postgres-types"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
 dependencies = [
  "bytes",
+ "fallible-iterator",
+ "postgres-protocol 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.9"
+source = "git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13#ad68abfd48b39a433bb4127bf1ae140b9be64d9e"
+dependencies = [
+ "bytes",
  "chrono",
  "fallible-iterator",
- "postgres-protocol",
+ "postgres-protocol 0.6.8 (git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13)",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -608,7 +641,7 @@ version = "0.1.0"
 dependencies = [
  "deadpool-postgres",
  "thiserror",
- "tokio-postgres",
+ "tokio-postgres 0.7.13 (git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13)",
 ]
 
 [[package]]
@@ -624,10 +657,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sha2"
@@ -708,8 +789,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+source = "git+https://github.com/dtolnay/thiserror?tag=2.0.16#40b58536cc4570d7e94575d1c90ebb07edf9aba0"
 dependencies = [
  "thiserror-impl",
 ]
@@ -717,8 +797,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+source = "git+https://github.com/dtolnay/thiserror?tag=2.0.16#40b58536cc4570d7e94575d1c90ebb07edf9aba0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -772,8 +851,33 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project-lite",
- "postgres-protocol",
- "postgres-types",
+ "postgres-protocol 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres-types 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.13"
+source = "git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13#ad68abfd48b39a433bb4127bf1ae140b9be64d9e"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol 0.6.8 (git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13)",
+ "postgres-types 0.2.9 (git+https://github.com/rust-postgres/rust-postgres?tag=tokio-postgres-v0.7.13)",
  "rand",
  "socket2",
  "tokio",
@@ -857,6 +961,16 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-deadpool-postgres = "0.14.1"
-thiserror = "2.0.16"
-tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4"] }
+deadpool-postgres = { git ="https://github.com/deadpool-rs/deadpool", tag= "deadpool-postgres-v0.14.1" }
+thiserror = { git = "https://github.com/dtolnay/thiserror", tag = "2.0.16" }
+tokio-postgres = { git = "https://github.com/rust-postgres/rust-postgres", tag = "tokio-postgres-v0.7.13", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }


### PR DESCRIPTION
Using an `impl` of `GenericClient` allows for a transaction to be used instead of a client.